### PR TITLE
Changed to test class instead of file name or path

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -69,5 +69,5 @@
     "Test::META",
     "File::Temp"
   ],
-  "version" : "0.3"
+  "version" : "0.2"
 }

--- a/t/22-diff.t
+++ b/t/22-diff.t
@@ -26,7 +26,7 @@ isa-ok my $delta = $diff.delta(0), Git::Diff::Delta, 'delta';
 
 is $delta.status, 'GIT_DELTA_ADDED', 'status';
 
-is $delta.old-file, Git::Diff::File, 'no old file';
+isa-ok $delta.old-file, Git::Diff::File, 'no old file';
 with $delta.new-file
 {
     is .id, '5966fc318ca68de951b63a9db21a4c1e07afa1ae', 'id';


### PR DESCRIPTION
Curt, I'm not sure of your intent, but that was the easiest fix for the only failing test on my Debian Buster 10 host with the latest Raku release.